### PR TITLE
Fix build steps

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
+github "NYPL-Simplified/r2-shared-swift" "0871e205c32f74d28f6fa254751e61ce784451fc"
 github "cezheng/Fuzi" "3.1.2"
 github "dexman/Minizip" "1.4.0"
 github "krzyzanowskim/CryptoSwift" "1.3.1"
-github "NYPL-Simplified/r2-shared-swift" "0871e205c32f74d28f6fa254751e61ce784451fc"
 github "stephencelis/SQLite.swift" "0.12.2"
 github "weichsel/ZIPFoundation" "0.9.11"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,23 @@ Swift wrapper module for LCP support
 
 [Changes and releases are documented in the Changelog](CHANGELOG.md)
 
+## Building r2-lcp-swift
+
+To build r2-lcp-swift you will require an external private framework for handling LCP DRM secrets. You should contact the appropriate LCP stakeholders to obtain access. As you can see in the code, this private framework is called `R2LCPClient`.
+
+Within NYPL `R2LCPClient` is available via the private `Certificates` repo. Clone `Certificates` as a sibling of the `r2-lcp-client` repo:
+
+```bash
+git clone git@github.com:NYPL-Simplified/r2-lcp-swift.git
+git clone git@github.com:NYPL-Simplified/Certificates.git
+cd r2-lcp-swift
+swift ../Certificates/SimplyE/iOS/LCPLib.swift -f
+carthage update --platform iOS
+```
+
 ## Adding the library to your iOS project
 
-> _Note:_ requires Swift 4.2 (and Xcode 10.1).
+> _Note:_ requires Swift 4.2 (and Xcode 11.5).
 
 ### Carthage
 
@@ -18,7 +32,7 @@ install ReadiumLCP with Carthage:
  2. Update your Cartfile to include the following:
 
     ```ruby
-    github "readium/r2-lcp-swift" "develop"
+    github "NYPL-Simplified/r2-lcp-swift" "develop"
     ```
 
  3. Run `carthage update` and
@@ -65,5 +79,3 @@ ReadiumLCP with CocoaPods:
   - [ZIPFoundation](https://github.com/edrlab/ZIPFoundation) : Effortless ZIP Handling in Swift
   - [SQLite.swift](https://github.com/stephencelis/SQLite.swift) : A type-safe, Swift-language layer over SQLite3.
   - [CryptoSwift](https://github.com/krzyzanowskim/CryptoSwift) : CryptoSwift is a growing collection of standard and secure cryptographic algorithms implemented in Swift
-
-

--- a/r2-lcp-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/r2-lcp-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This adds the private LCP binary framework as a dependency of r2-lcp-swift, so that it's localized to where it's used.

This is dependent on the following PR: https://github.com/NYPL-Simplified/Certificates/pull/14